### PR TITLE
fix #76 : Types findable when used as npm lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "filestack-react",
   "version": "3.2.0",
   "main": "dist/filestack-react.js",
+  "types": "src/index.d.ts",
   "description": "React component wrapper for filestack-js",
   "scripts": {
     "test": "jest --no-cache --coverage",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,24 +1,28 @@
 import React from 'react';
-import { PickerFileMetadata, ClientOptions } from 'filestack-js';
+import type { PickerFileMetadata, ClientOptions, PickerResponse } from 'filestack-js';
 
 type FilestackAction = 'transform' | 'retrieve' | 'metadata' | 'storeUrl' | 'upload' | 'multiupload' | 'remove' | 'pick' | 'removeMetadata' | 'preview' | 'logout';
 
 type ComponentDisplayModeType = 'button' | 'link' | 'immediate';
 
 interface Props {
-  apikey: string;
+  apikey?: string;
   action?: FilestackAction;
   componentDisplayMode?: {
     type?: ComponentDisplayModeType;
     customText?: string;
     customClass?: string;
   };
-  onSuccess?: (result: PickerFileMetadata[]) => void;
+  onSuccess?: (result: PickerResponse) => void;
   onError?: (error: PickerFileMetadata[]) => void;
   clientOptions?: ClientOptions;
   file?: File;
   source?: string;
-  customRender?: React.ComponentType;
+  customRender?: React.ComponentType<{ onPick: (arg: unknown) => void }>;
+
+  // Maps to pickerOptions in filestack-js
+  // https://filestack.github.io/filestack-js/interfaces/pickeroptions.html
+  actionOptions?: Record<string, unknown>;
 }
 
 declare class ReactFilestack extends React.Component<Props> {}


### PR DESCRIPTION
TypeScript types weren't getting recognized because package.json was missing the "types" property.

I also beefed up the types to get my own project to compile without warnings. 