### PR TITLE
closes #157: vite resolves filestack-react version 6.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "url": "git+https://github.com/filestack/filestack-react.git"
   },
   "main": "dist/filestack-react.js",
-  "module": "dist/filestack-react.modern.js",
+  "module": "dist/filestack-react.modern.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/filestack-react.modern.mjs",
+      "require": "./dist/filestack-react.js",
+      "default": "./dist/filestack-react.modern.mjs"
+    }
+  },
   "source": "src/index.js",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Tested the Picker on my Vite app that didn't work before with `filestack-react` version 6, with this newly packed version (`npm pack`), and there is no more error

Issue: #157 

@sethk4783 