### PR TITLE
FS-12861 | Fix v6.1.0 build compatibility, restore use client, and resolve JSX config errors

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "..": {
-      "version": "6.2.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",

--- a/nextjs-example/package-lock.json
+++ b/nextjs-example/package-lock.json
@@ -16,7 +16,7 @@
       }
     },
     "..": {
-      "version": "6.2.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",
@@ -25,8 +25,8 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.1.0",
         "@types/jest": "^29.5.14",
-        "@types/react": "^18.3.29",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.15",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "aws-sdk": "^2.1304.0",
@@ -51,10 +51,10 @@
         "microbundle": "^0.15.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.3",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "react-scripts": "^5.0.1",
-        "react-test-renderer": "^18.3.1",
+        "react-test-renderer": "^19.2.6",
         "standard-version": "^9.5.0",
         "through2": "^4.0.2",
         "typescript": "^4.9.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "filestack-react",
-      "version": "6.2.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "typescript"
   ],
   "scripts": {
-    "build": "microbundle --format modern,cjs --no-compress",
-    "build:prod": "microbundle --format modern,cjs",
+    "build": "microbundle --format modern,cjs --no-compress && node scripts/add-use-client.mjs",
+    "build:prod": "microbundle --format modern,cjs && node scripts/add-use-client.mjs",
     "start": "microbundle watch --format modern,cjs --no-compress",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build",

--- a/remix-example/package-lock.json
+++ b/remix-example/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "..": {
-      "version": "6.2.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",

--- a/scripts/add-use-client.mjs
+++ b/scripts/add-use-client.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Prepend the `'use client'` directive to the bundled entry files.
+ *
+ * microbundle/Rollup strips module-level directives when it merges the
+ * `src/*.tsx` modules into a single bundle (the "Module level directives
+ * cause errors when bundled, 'use client' was ignored" warning). Without the
+ * directive in `dist/`, the published components can only be imported from
+ * within a consumer's own client component — importing them directly into a
+ * Next.js App Router Server Component would fail. Re-adding it here restores
+ * that boundary so the bundle is usable from either context.
+ *
+ * Targets are read from package.json `main`/`module` so this stays in sync
+ * with the build output. Safe to run repeatedly (skips files that already
+ * start with the directive).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const DIRECTIVE = "'use client';";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+
+const targets = [pkg.main, pkg.module].filter(Boolean);
+
+for (const rel of targets) {
+  const file = resolve(root, rel);
+  const code = readFileSync(file, 'utf8');
+
+  // Already present (allowing an optional leading BOM / whitespace)?
+  if (/^\s*['"]use client['"];?/.test(code)) {
+    console.log(`use-client: already present in ${rel}`);
+    continue;
+  }
+
+  writeFileSync(file, `${DIRECTIVE}\n${code}`);
+  console.log(`use-client: prepended to ${rel}`);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "jsx": "react-jsx",
+    "jsxFactory": "",
+    "jsxFragmentFactory": "",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,

--- a/vite-example/package-lock.json
+++ b/vite-example/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "..": {
-      "version": "6.2.0",
+      "version": "6.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/eslint-parser": "^7.19.1",


### PR DESCRIPTION
1. Changed package-lock.json to support v6.1.0
2. Added scripts/add-use-client.mjs is a post-build step that re-adds the 'use client'; directive to the bundled output files.
3. Fix 'jsxFactory' error on install step